### PR TITLE
Infer dayobs from DATE-OBS keyword if it does not exist.

### DIFF
--- a/lco_ingester/fits.py
+++ b/lco_ingester/fits.py
@@ -6,7 +6,7 @@ from astropy.io import fits
 from dateutil.parser import parse
 
 from lco_ingester.exceptions import DoNotRetryError
-from lco_ingester.utils.fits import reduction_level, related_for_catalog
+from lco_ingester.utils.fits import reduction_level, related_for_catalog, dateobs_to_dayobs
 from lco_ingester.utils.fits import File
 from lco_ingester.settings import settings
 
@@ -75,9 +75,9 @@ class FitsDict(object):
             self.fits_dict['OBSTYPE'] = 'CATALOG'
 
     def check_dayobs(self):
-        if not self.fits_dict.get('DAY_OBS'):
+        if not self.fits_dict.get('DAY-OBS'):
             date_obs = self.fits_dict.get('DATE-OBS')
-            self.fits_dict['DAY_OBS'] = date_obs.split('T')[0].replace('-', '')
+            self.fits_dict['DAY-OBS'] = dateobs_to_dayobs(date_obs)
 
     def set_public_date(self):
         if not self.fits_dict.get('L1PUBDAT'):

--- a/lco_ingester/fits.py
+++ b/lco_ingester/fits.py
@@ -74,6 +74,11 @@ class FitsDict(object):
             # set obstype to CATALOG even though it's set to EXPOSE by the pipeline
             self.fits_dict['OBSTYPE'] = 'CATALOG'
 
+    def check_dayobs(self):
+        if not self.fits_dict.get('DAY_OBS'):
+            date_obs = self.fits_dict.get('DATE-OBS')
+            self.fits_dict['DAY_OBS'] = date_obs.split('T')[0].replace('-', '')
+
     def set_public_date(self):
         if not self.fits_dict.get('L1PUBDAT'):
             # Check if the frame doesnt specify a public date.
@@ -132,6 +137,7 @@ class FitsDict(object):
         self.normalize_null_values()
         self.check_rlevel()
         self.check_catalog()
+        self.check_dayobs()
         self.set_public_date()
         self.normalize_related()
         return self.fits_dict

--- a/lco_ingester/fits.py
+++ b/lco_ingester/fits.py
@@ -6,7 +6,7 @@ from astropy.io import fits
 from dateutil.parser import parse
 
 from lco_ingester.exceptions import DoNotRetryError
-from lco_ingester.utils.fits import reduction_level, related_for_catalog, dateobs_to_dayobs
+from lco_ingester.utils.fits import reduction_level, related_for_catalog, get_dayobs
 from lco_ingester.utils.fits import File
 from lco_ingester.settings import settings
 
@@ -75,9 +75,7 @@ class FitsDict(object):
             self.fits_dict['OBSTYPE'] = 'CATALOG'
 
     def check_dayobs(self):
-        if not self.fits_dict.get('DAY-OBS'):
-            date_obs = self.fits_dict.get('DATE-OBS')
-            self.fits_dict['DAY-OBS'] = dateobs_to_dayobs(date_obs)
+        self.fits_dict['DAY-OBS'] = get_dayobs(self.fits_dict)
 
     def set_public_date(self):
         if not self.fits_dict.get('L1PUBDAT'):

--- a/lco_ingester/s3.py
+++ b/lco_ingester/s3.py
@@ -3,7 +3,7 @@ import logging
 from io import BytesIO
 from datetime import datetime
 
-from lco_ingester.utils.fits import get_storage_class
+from lco_ingester.utils.fits import get_storage_class, dateobs_to_dayobs
 from opentsdb_python_metrics.metric_wrappers import metric_timer, SendMetricMixin
 from botocore.exceptions import EndpointConnectionError, ConnectionClosedError
 
@@ -38,7 +38,7 @@ class S3Service(SendMetricMixin):
         if not day_obs:
             # SOR files don't have the day_obs in their filename or header, so use the DATE_OBS field:
             date_obs = fits_dict.get('DATE-OBS')
-            day_obs = date_obs.split('T')[0].replace('-', '')
+            day_obs = dateobs_to_dayobs(date_obs)
         if self.is_bpm_file(file.basename, fits_dict):
             # Files with bpm in the name, or BPM OBSTYPE or EXTNAME headers are placed in the instrument/bpm/ dir
             return '/'.join((site, instrument, 'bpm', file.basename)) + file.extension

--- a/lco_ingester/utils/fits.py
+++ b/lco_ingester/utils/fits.py
@@ -220,3 +220,14 @@ def related_for_catalog(basename):
     # being inferred from the filename
     # a file's corresponding catalog is that filename + _cat
     return basename.replace('_cat', '')
+
+
+def dateobs_to_dayobs(date_obs: str):
+    """
+    Infer dayobs from dateobs
+    :param dateobs: DATE-OBS FITS header value
+    :return: Date in DAY-OBS YYYYMMDD format
+    """
+    return date_obs.split('T')[0].replace('-', '')
+
+

--- a/lco_ingester/utils/fits.py
+++ b/lco_ingester/utils/fits.py
@@ -222,12 +222,18 @@ def related_for_catalog(basename):
     return basename.replace('_cat', '')
 
 
-def dateobs_to_dayobs(date_obs: str):
+def get_dayobs(fits_dict: dict):
     """
-    Infer dayobs from dateobs
-    :param dateobs: DATE-OBS FITS header value
+    Get dayobs from a fits_dict
+    :param fits_dict: Fits dictionary with required header keywords
     :return: Date in DAY-OBS YYYYMMDD format
     """
-    return date_obs.split('T')[0].replace('-', '')
+    day_obs = fits_dict.get('DAY-OBS')
+    if not day_obs:
+        # Fall back to DATE-OBS
+        date_obs = fits_dict.get('DATE-OBS')
+        day_obs = date_obs.split('T')[0].replace('-', '')
+
+    return day_obs
 
 

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -50,6 +50,12 @@ class TestFits(unittest.TestCase):
         fd.check_rlevel()
         self.assertEqual(11, fd.fits_dict['RLEVEL'])
 
+    def test_dayobs_missing(self):
+        fd = FitsDict(File(self.fileobj), [], [])
+        fd.fits_dict = {'DATE-OBS': '2020-01-31T20:09:56.956'}
+        fd.check_dayobs()
+        self.assertEqual('20200131', fd.fits_dict['DAY_OBS'])
+
     def test_catalog_file(self):
         self.fileobj.name = 'something-e90_cat.fits.fz'
         fd = FitsDict(File(self.fileobj), [], [])

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -54,7 +54,7 @@ class TestFits(unittest.TestCase):
         fd = FitsDict(File(self.fileobj), [], [])
         fd.fits_dict = {'DATE-OBS': '2020-01-31T20:09:56.956'}
         fd.check_dayobs()
-        self.assertEqual('20200131', fd.fits_dict['DAY_OBS'])
+        self.assertEqual('20200131', fd.fits_dict['DAY-OBS'])
 
     def test_catalog_file(self):
         self.fileobj.name = 'something-e90_cat.fits.fz'

--- a/tests/test_ingester.py
+++ b/tests/test_ingester.py
@@ -139,9 +139,9 @@ class TestIngester(unittest.TestCase):
 
     def test_blacklist(self):
         ingester = self.ingesters[0]
-        ingester.blacklist_headers = ['DAY-OBS', '', 'COMMENT', 'HISTORY']
+        ingester.blacklist_headers = ['', 'COMMENT', 'HISTORY']
         ingester.ingest()
-        self.assertNotIn('DAY-OBS', self.archive_mock.post_frame.call_args[0][0].keys())
+        self.assertNotIn('COMMENT', self.archive_mock.post_frame.call_args[0][0].keys())
 
     def test_reduction_level(self):
         for ingester in self.ingesters:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 import io
 import hashlib
 import unittest
-from lco_ingester.utils.fits import File, reduction_level
+from lco_ingester.utils.fits import File, reduction_level, get_dayobs
 
 
 class TestFitsUtils(unittest.TestCase):
@@ -57,3 +57,12 @@ class TestFitsUtils(unittest.TestCase):
             md52 = file.get_md5()
             self.assertEqual(md51, md52)
             self.assertEqual(md5bstring, md51)
+
+    def test_get_dayobs_no_dayobs(self):
+        fits_dict = {'DATE-OBS': '2020-01-31T20:09:56.956'}
+        self.assertEqual('20200131', get_dayobs(fits_dict))
+
+    def test_get_dayobs(self):
+        fits_dict = {'DAY-OBS': '20200131'}
+        self.assertEqual('20200131', get_dayobs(fits_dict))
+


### PR DESCRIPTION
When working with Diego from SOAR debugging the ingestion of images, I found that the Archive API `frames/` endpoint was rejecting all new SOAR fits dicts with a 400 error. 

After some digging, I found that this was due to the addition of the DAY_OBS field in the frame model. Since SOAR frames don't have dayobs in their fits headers, the `FitsDict`s did not have dayobs present, and were being rejected.

It appears that while we correctly create s3 keys using dayobs now, we never actually updated the FitsDict logic to match the updated archive model, and it never became a problem until now because LCO images all have dayobs present. 

I was able to reproduce this exact error on the dev archive with a SOAR frame that Diego sent to me, and I have tested this fix there. Here is the ingested frame record: http://archive-api-dev.lco.gtn/frames/7128/

I used Jon's method for inferring dayobs from date-obs here: https://github.com/LCOGT/ingester/blob/0a38ef2267f3100064fd620925ff08bc8a49eace/lco_ingester/s3.py#L38 
