### PR TITLE
Extra metrics tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ set as environment variables.
 | | `AWS_DEFAULT_REGION` | AWS S3 Default Region | `""`
 | Metrics | `OPENTSDB_HOSTNAME` | OpenTSDB Host to send metrics to | `""`
 | | `OPENTSDB_PYTHON_METRICS_TEST_MODE` | Set to any value to turn off metrics collection | `False`
+| | `INGESTER_PROCESS_NAME` | A tag set with the collected metrics to identify where the metrics are coming from | `ingester`
 | Postprocessing | `FITS_BROKER` | FITS exchange broker  | `memory://localhost`
 | | `PROCESSED_EXCHANGE_NAME` | Processed files RabbitMQ Exchange Name | `archived_fits`
 | | `POSTPROCESS_FILES` | Optionally submit files to fits queue  | `True`

--- a/lco_ingester/s3.py
+++ b/lco_ingester/s3.py
@@ -1,16 +1,16 @@
-import hashlib
 import logging
 from io import BytesIO
 from datetime import datetime
 
 from lco_ingester.utils.fits import get_storage_class
-from opentsdb_python_metrics.metric_wrappers import metric_timer, SendMetricMixin
+from opentsdb_python_metrics.metric_wrappers import metric_timer_with_tags, SendMetricMixin
 from botocore.exceptions import EndpointConnectionError, ConnectionClosedError
 
 import requests
 import boto3
 
 from lco_ingester.exceptions import BackoffRetryError
+from lco_ingester.settings import settings
 
 logger = logging.getLogger('lco_ingester')
 
@@ -61,7 +61,7 @@ class S3Service(SendMetricMixin):
         if etag.startswith('"') and etag.endswith('"'):
             return etag[1:-1]
 
-    @metric_timer('ingester.upload_file')
+    @metric_timer_with_tags('ingester.upload_file', ingester_process_name=settings.INGESTER_PROCESS_NAME)
     def upload_file(self, file, fits_dict):
         storage_class = get_storage_class(fits_dict)
         start_time = datetime.utcnow()
@@ -91,7 +91,11 @@ class S3Service(SendMetricMixin):
         # Record metric for the bytes transferred / time to upload
         upload_time = datetime.utcnow() - start_time
         bytes_per_second = len(file) / upload_time.total_seconds()
-        self.send_metric('ingester.s3_upload_bytes_per_second', bytes_per_second)
+        self.send_metric(
+            'ingester.s3_upload_bytes_per_second',
+            bytes_per_second,
+            ingester_process_name=settings.INGESTER_PROCESS_NAME
+        )
         # TODO: Remove 'migrated': True from the return dict when the s3 migration is complete
         return {'key': key, 'md5': s3_md5, 'extension': file.extension, 'migrated': True}
 

--- a/lco_ingester/scripts/ingest_frame.py
+++ b/lco_ingester/scripts/ingest_frame.py
@@ -3,6 +3,7 @@ import sys
 import argparse
 
 from lco_ingester.ingester import frame_exists, upload_file_and_ingest_to_archive
+from lco_ingester.settings import settings
 from lco_ingester.exceptions import NonFatalDoNotRetryError
 
 description = (
@@ -18,10 +19,14 @@ def main():
     parser.add_argument('--api-root', help='API root')
     parser.add_argument('--auth-token', help='API token')
     parser.add_argument('--bucket', help='S3 bucket name')
+    parser.add_argument('--process-name', help='Tag set in collected metrics')
     parser.add_argument('--check-only', action='store_true', help='Only check if the frame exists in the archive. \
                                                                    returns a status code of 0 if found, 1 if not \
-                                                                   (or an error occured)')
+                                                                   (or an error occurred)')
     args = parser.parse_args()
+
+    if args.process_name:
+        settings.EXTRA_METRICS_TAGS['ingester_process_name'] = args.process_name
 
     try:
         with open(args.path, 'rb') as fileobj:

--- a/lco_ingester/scripts/ingest_frame.py
+++ b/lco_ingester/scripts/ingest_frame.py
@@ -25,6 +25,9 @@ def main():
                                                                    (or an error occurred)')
     args = parser.parse_args()
 
+    # Submit metrics synchronously so that they all get submitted before the program exits
+    settings.SUBMIT_METRICS_ASYNCHRONOUSLY = False
+
     if args.process_name:
         settings.EXTRA_METRICS_TAGS['ingester_process_name'] = args.process_name
 
@@ -36,6 +39,7 @@ def main():
                         k: v for k, v in vars(args).items() if k in ['api_root', 'auth_token'] and v is not None
                     }
                     exists = frame_exists(fileobj, **check_args)
+
                 except Exception as e:
                     sys.stdout.write(str(e))
                     sys.exit(1)

--- a/lco_ingester/settings/settings.py
+++ b/lco_ingester/settings/settings.py
@@ -44,5 +44,7 @@ PROCESSED_EXCHANGE_NAME = os.getenv('PROCESSED_EXCHANGE_NAME', 'archived_fits')
 # Optionally submit files to fits queue
 POSTPROCESS_FILES = ast.literal_eval(os.getenv('POSTPROCESS_FILES', 'True'))
 
-# Extra tag for metrics, set this value per process to identify where the metrics are coming from
-INGESTER_PROCESS_NAME = os.getenv('INGESTER_PROCESS_NAME', 'ingester')
+# Extra tags for metrics
+EXTRA_METRICS_TAGS = {
+    'ingester_process_name': os.getenv('INGESTER_PROCESS_NAME', 'ingester')
+}

--- a/lco_ingester/settings/settings.py
+++ b/lco_ingester/settings/settings.py
@@ -1,6 +1,7 @@
 import os
 import ast
 
+
 def get_tuple_from_environment(variable_name, default):
     return tuple(os.getenv(variable_name, default).strip(',').replace(' ', '').split(','))
 
@@ -42,3 +43,6 @@ PROCESSED_EXCHANGE_NAME = os.getenv('PROCESSED_EXCHANGE_NAME', 'archived_fits')
 
 # Optionally submit files to fits queue
 POSTPROCESS_FILES = ast.literal_eval(os.getenv('POSTPROCESS_FILES', 'True'))
+
+# Extra tag for metrics, set this value per process to identify where the metrics are coming from
+INGESTER_PROCESS_NAME = os.getenv('INGESTER_PROCESS_NAME', 'ingester')

--- a/lco_ingester/settings/settings.py
+++ b/lco_ingester/settings/settings.py
@@ -44,6 +44,9 @@ PROCESSED_EXCHANGE_NAME = os.getenv('PROCESSED_EXCHANGE_NAME', 'archived_fits')
 # Optionally submit files to fits queue
 POSTPROCESS_FILES = ast.literal_eval(os.getenv('POSTPROCESS_FILES', 'True'))
 
+# Whether to submit the metrics asynchronously
+SUBMIT_METRICS_ASYNCHRONOUSLY = True
+
 # Extra tags for metrics
 EXTRA_METRICS_TAGS = {
     'ingester_process_name': os.getenv('INGESTER_PROCESS_NAME', 'ingester')

--- a/lco_ingester/utils/fits.py
+++ b/lco_ingester/utils/fits.py
@@ -4,12 +4,11 @@ import tarfile
 import hashlib
 import os
 
-from opentsdb_python_metrics.metric_wrappers import metric_timer_with_tags
 from dateutil.parser import parse
 from astropy import wcs
 
 from lco_ingester.exceptions import DoNotRetryError
-from lco_ingester.settings import settings
+from lco_ingester.utils import metrics
 
 
 class File:
@@ -60,7 +59,7 @@ class File:
                 return tarfileobj.extractfile(member)
         raise DoNotRetryError('Spectral package missing meta fits!')
 
-    @metric_timer_with_tags('ingester.get_md5', ingester_process_name=settings.INGESTER_PROCESS_NAME)
+    @metrics.method_timer('ingester.get_md5')
     def get_md5(self):
         return hashlib.md5(self.get_from_start().read()).hexdigest()
 

--- a/lco_ingester/utils/fits.py
+++ b/lco_ingester/utils/fits.py
@@ -4,11 +4,12 @@ import tarfile
 import hashlib
 import os
 
-from opentsdb_python_metrics.metric_wrappers import metric_timer
+from opentsdb_python_metrics.metric_wrappers import metric_timer_with_tags
 from dateutil.parser import parse
 from astropy import wcs
 
 from lco_ingester.exceptions import DoNotRetryError
+from lco_ingester.settings import settings
 
 
 class File:
@@ -59,7 +60,7 @@ class File:
                 return tarfileobj.extractfile(member)
         raise DoNotRetryError('Spectral package missing meta fits!')
 
-    @metric_timer('ingester.get_md5')
+    @metric_timer_with_tags('ingester.get_md5', ingester_process_name=settings.INGESTER_PROCESS_NAME)
     def get_md5(self):
         return hashlib.md5(self.get_from_start().read()).hexdigest()
 

--- a/lco_ingester/utils/metrics.py
+++ b/lco_ingester/utils/metrics.py
@@ -10,8 +10,8 @@ def method_timer(metric_name):
     def method_timer_decorator(method):
         def wrapper(self, *args, **kwargs):
             # Decorate the wrapped method with metric_timer_with_tags, which does the work of figuring out
-            # the runtime, so that the EXTRA_METRICS_TAGS are evaluated at runtime. An example of when the
-            # value is changed at runtime is when the ingester command line entrypoint is used.
+            # how long a method takes to run, so that the settings used are evaluated at runtime. An example
+            # of when settings are changed at runtime is when the ingester command line entrypoint is used.
             @metric_timer_with_tags(
                 metric_name=metric_name,
                 asynchronous=settings.SUBMIT_METRICS_ASYNCHRONOUSLY,

--- a/lco_ingester/utils/metrics.py
+++ b/lco_ingester/utils/metrics.py
@@ -2,7 +2,7 @@ import functools
 
 from opentsdb_python_metrics.metric_wrappers import metric_timer_with_tags
 
-from lco_ingester.settings.settings import EXTRA_METRICS_TAGS
+from lco_ingester.settings import settings
 
 
 def method_timer(metric_name):
@@ -12,7 +12,11 @@ def method_timer(metric_name):
             # Decorate the wrapped method with metric_timer_with_tags, which does the work of figuring out
             # the runtime, so that the EXTRA_METRICS_TAGS are evaluated at runtime. An example of when the
             # value is changed at runtime is when the ingester command line entrypoint is used.
-            @metric_timer_with_tags(metric_name, **EXTRA_METRICS_TAGS)
+            @metric_timer_with_tags(
+                metric_name=metric_name,
+                asynchronous=settings.SUBMIT_METRICS_ASYNCHRONOUSLY,
+                **settings.EXTRA_METRICS_TAGS
+            )
             @functools.wraps(method)
             def run_method(self, *args, **kwargs):
                 return method(self, *args, **kwargs)

--- a/lco_ingester/utils/metrics.py
+++ b/lco_ingester/utils/metrics.py
@@ -1,0 +1,21 @@
+import functools
+
+from opentsdb_python_metrics.metric_wrappers import metric_timer_with_tags
+
+from lco_ingester.settings.settings import EXTRA_METRICS_TAGS
+
+
+def method_timer(metric_name):
+    """Decorator to add extra tags to collected runtime metrics"""
+    def method_timer_decorator(method):
+        def wrapper(self, *args, **kwargs):
+            # Decorate the wrapped method with metric_timer_with_tags, which does the work of figuring out
+            # the runtime, so that the EXTRA_METRICS_TAGS are evaluated at runtime. An example of when the
+            # value is changed at runtime is when the ingester command line entrypoint is used.
+            @metric_timer_with_tags(metric_name, **EXTRA_METRICS_TAGS)
+            @functools.wraps(method)
+            def run_method(self, *args, **kwargs):
+                return method(self, *args, **kwargs)
+            return run_method(self, *args, **kwargs)
+        return wrapper
+    return method_timer_decorator


### PR DESCRIPTION
I've added a process name setting to the library that is used as a tag in the collected metrics. This tag is meant to identify which user of the ingester library a metric came from. For example, the floyds pipeline might set this value to `floyds-pipeline`, and then we could easily filter down to metrics submitted by that pipeline.

This setting can be set by the `INGESTER_PROCESS_NAME` environment variable, or if using the command line utility, setting `--process-name` as an argument. 

In my testing, I found that there were a couple of metrics that never seemed to make it into opentsdb when using the command line utility. This is because the program would exit before the underlying metrics library had a chance to actually post the metrics to the db. To remedy this, I switched the metrics to submit synchronously when the command line entrypoint it used so that the metrics are guaranteed to get in. I've updated the underlying metrics client library to have a timeout when submitting metrics, so that the command line program will not hang indefinitely if there is a problem connecting.