### PR TITLE
Submit metrics synchronously by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ set as environment variables.
 | Metrics | `OPENTSDB_HOSTNAME` | OpenTSDB Host to send metrics to | `""`
 | | `OPENTSDB_PYTHON_METRICS_TEST_MODE` | Set to any value to turn off metrics collection | `False`
 | | `INGESTER_PROCESS_NAME` | A tag set with the collected metrics to identify where the metrics are coming from | `ingester`
+| | `SUBMIT_METRICS_ASYNCHRONOUSLY` | Optionally submit metrics asynchronously. This option does not apply when the command line entrypoint is used, in which case metrics are always submitted synchronously. Note that some metrics may be lost when submitted asynchronously. | `False`
 | Postprocessing | `FITS_BROKER` | FITS exchange broker  | `memory://localhost`
 | | `PROCESSED_EXCHANGE_NAME` | Processed files RabbitMQ Exchange Name | `archived_fits`
 | | `POSTPROCESS_FILES` | Optionally submit files to fits queue  | `True`

--- a/lco_ingester/settings/settings.py
+++ b/lco_ingester/settings/settings.py
@@ -45,7 +45,7 @@ PROCESSED_EXCHANGE_NAME = os.getenv('PROCESSED_EXCHANGE_NAME', 'archived_fits')
 POSTPROCESS_FILES = ast.literal_eval(os.getenv('POSTPROCESS_FILES', 'True'))
 
 # Whether to submit the metrics asynchronously
-SUBMIT_METRICS_ASYNCHRONOUSLY = True
+SUBMIT_METRICS_ASYNCHRONOUSLY = ast.literal_eval(os.getenv('SUBMIT_METRICS_ASYNCHRONOUSLY', 'False'))
 
 # Extra tags for metrics
 EXTRA_METRICS_TAGS = {


### PR DESCRIPTION
Default to always submit metrics synchronously. This is safer as submitting asynchronously could result in lost metrics.