### PR TITLE
Fix/http client error

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+2.1.13
+2020-03-04
+Fix retry logic for HTTP 4xx Client Errors
+
 2.1.12
 2020-02-26
 Submit all metrics synchronously by default

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='lco-ingester',
-    version='2.1.12',
+    version='2.1.13',
     description='Ingest frames into the LCO Archive',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -5,14 +5,15 @@ from requests.exceptions import ConnectionError, HTTPError
 
 from lco_ingester.archive import PostProcService
 from lco_ingester.archive import ArchiveService
-from lco_ingester.exceptions import NonFatalDoNotRetryError, RetryError, BackoffRetryError
+from lco_ingester.exceptions import BackoffRetryError, DoNotRetryError
 
 
 def mocked_requests_get(*args, **kwargs):
     class MockResponse(object):
-        def __init__(self, json_data, exception):
+        def __init__(self, json_data, exception, status_code):
             self.json_data = json_data
             self.exception = exception
+            self.status_code = status_code
 
         def json(self):
             return self.json_data
@@ -24,15 +25,15 @@ def mocked_requests_get(*args, **kwargs):
                 return None
 
     if args[0].startswith('http://return1/'):
-        return MockResponse({'count': 1}, None)
+        return MockResponse({'count': 1}, None, 400)
 
     if args[0].startswith('http://return404/'):
-        return MockResponse(None, HTTPError)
+        return MockResponse(None, HTTPError, 404)
 
     if args[0].startswith('http://badconnection/'):
-        return MockResponse(None, ConnectionError)
+        return MockResponse(None, ConnectionError, 500)
 
-    return MockResponse({'count': 0}, None)
+    return MockResponse({'count': 0}, None, 200)
 
 
 @patch('requests.get', side_effect=mocked_requests_get)
@@ -61,7 +62,7 @@ class TestArchiveService(unittest.TestCase):
 
     def test_bad_response(self, post_mock, get_mock):
         archive_service = ArchiveService(api_root='http://return404/', auth_token='', broker_url='')
-        with self.assertRaises(RetryError):
+        with self.assertRaises(DoNotRetryError):
             archive_service.version_exists('')
         self.assertFalse(post_mock.called)
 


### PR DESCRIPTION
HTTP 4xx errors are Client Errors (bad data in request generated by the client). Retrying a request containing bad data is nonsense: the bad data will always be there, so retrying is futile. Make this clear by returning a `DoNotRetryError` in this case.

Also, as usual, I'll need help getting this built correctly and uploaded to PyPI.